### PR TITLE
feat: add wallet modal workflow and refine dashboard UI on ryan_b

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1353,5 +1353,5 @@ def create_app(config_name='development'):
 
 if __name__ == '__main__':
     app = create_app(os.environ.get('FLASK_ENV', 'development'))
-    port = int(os.environ.get('PORT', 8000))
+    port = int(os.environ.get('PORT', 5000))
     app.run(debug=app.config.get('DEBUG', False), host='0.0.0.0', port=port)

--- a/src/app.py
+++ b/src/app.py
@@ -13,7 +13,7 @@ from werkzeug.utils import secure_filename
 sys.path.insert(0, os.path.dirname(__file__))
 
 from config import config
-from models import Conversation, Item, ItemImage, Message, Transaction, User, db
+from models import Conversation, Item, ItemImage, Message, PaymentMethod, Transaction, User, Wallet, WalletEntry, db
 
 
 ITEM_CATEGORIES = ['Electronics', 'Furniture', 'Clothing', 'Books', 'Sports', 'Other']
@@ -23,6 +23,12 @@ MAX_MESSAGE_LENGTH = 600
 MAX_IMAGES_PER_ITEM = 6
 ALLOWED_IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.webp', '.gif'}
 DRAFT_TITLE_PLACEHOLDER = 'Untitled draft'
+MAX_WALLET_ACTIVITY = 8
+MIN_TOP_UP_AMOUNT = 5.0
+MAX_TOP_UP_AMOUNT = 2000.0
+MIN_WITHDRAWAL_AMOUNT = 5.0
+WITHDRAWAL_FEE_RATE = 0.02
+WITHDRAWAL_FEE_MINIMUM = 0.50
 
 
 def is_valid_uwa_student_email(email):
@@ -151,6 +157,243 @@ def create_app(config_name='development'):
             ))
 
         return image_records, saved_paths
+
+    def round_money(value):
+        return round(float(value or 0) + 1e-9, 2)
+
+    def format_money(value):
+        return f'{round_money(value):.2f}'
+
+    def calculate_withdrawal_fee(amount):
+        return round_money(max(WITHDRAWAL_FEE_MINIMUM, amount * WITHDRAWAL_FEE_RATE))
+
+    def get_or_create_wallet(user, *, commit=False):
+        wallet = Wallet.query.filter_by(user_id=user.id).first()
+        if wallet:
+            return wallet
+
+        wallet = Wallet(user_id=user.id, available_balance=0.0)
+        db.session.add(wallet)
+        db.session.flush()
+        if commit:
+            db.session.commit()
+        return wallet
+
+    def ensure_existing_users_have_wallets():
+        user_ids_with_wallets = {wallet_user_id for wallet_user_id, in db.session.query(Wallet.user_id).all()}
+        missing_wallets = []
+        for user in User.query.all():
+            if user.id not in user_ids_with_wallets:
+                missing_wallets.append(Wallet(user_id=user.id, available_balance=0.0))
+
+        if missing_wallets:
+            db.session.add_all(missing_wallets)
+            db.session.commit()
+
+    def record_wallet_entry(wallet, entry_type, amount, description, *, payment_method=None, transaction=None):
+        entry = WalletEntry(
+            user_id=wallet.user_id,
+            payment_method_id=payment_method.id if payment_method else None,
+            transaction_id=transaction.id if transaction else None,
+            entry_type=entry_type,
+            amount=round_money(amount),
+            balance_after=round_money(wallet.available_balance),
+            description=description,
+        )
+        db.session.add(entry)
+        return entry
+
+    def get_user_payment_methods(user):
+        methods = PaymentMethod.query.filter_by(user_id=user.id).order_by(
+            PaymentMethod.is_default.desc(),
+            PaymentMethod.created_at.desc(),
+        ).all()
+        return methods
+
+    def get_default_payment_method(user):
+        return (
+            PaymentMethod.query
+            .filter_by(user_id=user.id, is_default=True)
+            .order_by(PaymentMethod.created_at.desc())
+            .first()
+        )
+
+    def resolve_payment_method(user, payment_method_id):
+        if payment_method_id:
+            method = db.session.get(PaymentMethod, payment_method_id)
+            if method and method.user_id == user.id:
+                return method
+            return None
+
+        default_method = get_default_payment_method(user)
+        if default_method:
+            return default_method
+
+        methods = get_user_payment_methods(user)
+        return methods[0] if methods else None
+
+    def mask_payment_number(raw_number):
+        digits_only = ''.join(character for character in raw_number if character.isdigit())
+        if len(digits_only) < 8:
+            return None, None
+        return digits_only[-4:], f'•••• {digits_only[-4:]}'
+
+    def add_payment_method(user, provider_name, account_holder, account_number, *, make_default=False):
+        provider_name = provider_name.strip()
+        account_holder = account_holder.strip()
+        last_four, masked_suffix = mask_payment_number(account_number)
+
+        if not provider_name or not account_holder or not last_four:
+            return None, 'Provider, cardholder name, and a valid bank card number are required.', 400
+
+        should_be_default = make_default or not PaymentMethod.query.filter_by(user_id=user.id).count()
+        if should_be_default:
+            PaymentMethod.query.filter_by(user_id=user.id, is_default=True).update({'is_default': False})
+
+        method = PaymentMethod(
+            user_id=user.id,
+            provider_name=provider_name,
+            account_holder=account_holder,
+            masked_details=f'{provider_name} {masked_suffix}',
+            last_four=last_four,
+            method_type='bank_card',
+            is_default=should_be_default,
+        )
+        db.session.add(method)
+        db.session.commit()
+        return method, None, 201
+
+    def top_up_wallet(user, payment_method_id, amount_raw):
+        method = resolve_payment_method(user, payment_method_id)
+        if not method:
+            return None, None, 'Link a bank card before topping up your wallet.', 400
+
+        try:
+            amount = round_money(float(amount_raw))
+        except (TypeError, ValueError):
+            return None, None, 'Top-up amount must be a valid number.', 400
+
+        if amount < MIN_TOP_UP_AMOUNT or amount > MAX_TOP_UP_AMOUNT:
+            return None, None, f'Top-ups must be between ${format_money(MIN_TOP_UP_AMOUNT)} and ${format_money(MAX_TOP_UP_AMOUNT)}.', 400
+
+        wallet = get_or_create_wallet(user)
+        wallet.available_balance = round_money(wallet.available_balance + amount)
+        entry = record_wallet_entry(
+            wallet,
+            'top_up',
+            amount,
+            f'Top-up from {method.masked_details}',
+            payment_method=method,
+        )
+        db.session.commit()
+        return wallet, entry, None, 200
+
+    def withdraw_from_wallet(user, payment_method_id, amount_raw):
+        method = resolve_payment_method(user, payment_method_id)
+        if not method:
+            return None, None, None, 'Link a bank card before requesting a withdrawal.', 400
+
+        try:
+            amount = round_money(float(amount_raw))
+        except (TypeError, ValueError):
+            return None, None, None, 'Withdrawal amount must be a valid number.', 400
+
+        if amount < MIN_WITHDRAWAL_AMOUNT:
+            return None, None, None, f'Withdrawals must be at least ${format_money(MIN_WITHDRAWAL_AMOUNT)}.', 400
+
+        wallet = get_or_create_wallet(user)
+        fee = calculate_withdrawal_fee(amount)
+        total_deduction = round_money(amount + fee)
+        if wallet.available_balance < total_deduction:
+            return None, None, None, (
+                f'Insufficient wallet balance. You need ${format_money(total_deduction)} '
+                f'available to withdraw ${format_money(amount)} after the fee.'
+            ), 400
+
+        wallet.available_balance = round_money(wallet.available_balance - amount)
+        withdrawal_entry = record_wallet_entry(
+            wallet,
+            'withdrawal',
+            -amount,
+            f'Withdrawal to {method.masked_details}',
+            payment_method=method,
+        )
+        wallet.available_balance = round_money(wallet.available_balance - fee)
+        fee_entry = record_wallet_entry(
+            wallet,
+            'withdrawal_fee',
+            -fee,
+            'Withdrawal processing fee',
+            payment_method=method,
+        )
+        db.session.commit()
+        return wallet, withdrawal_entry, fee_entry, None, 200
+
+    def serialize_payment_method(method):
+        return {
+            'id': method.id,
+            'provider_name': method.provider_name,
+            'account_holder': method.account_holder,
+            'masked_details': method.masked_details,
+            'last_four': method.last_four,
+            'method_type': method.method_type,
+            'is_default': method.is_default,
+            'created_at': method.created_at.isoformat(),
+            'created_at_display': format_timestamp(method.created_at),
+        }
+
+    def serialize_wallet_entry(entry):
+        amount = round_money(entry.amount)
+        return {
+            'id': entry.id,
+            'entry_type': entry.entry_type,
+            'description': entry.description,
+            'amount': amount,
+            'amount_display': format_money(amount),
+            'amount_sign': '+' if amount > 0 else '-',
+            'balance_after': round_money(entry.balance_after),
+            'balance_after_display': format_money(entry.balance_after),
+            'created_at': entry.created_at.isoformat(),
+            'created_at_display': format_timestamp(entry.created_at),
+            'payment_method': serialize_payment_method(entry.payment_method) if entry.payment_method else None,
+        }
+
+    def build_wallet_payload(user):
+        wallet = get_or_create_wallet(user, commit=True)
+        methods = get_user_payment_methods(user)
+        entries = (
+            WalletEntry.query
+            .filter_by(user_id=user.id)
+            .order_by(WalletEntry.created_at.desc())
+            .limit(MAX_WALLET_ACTIVITY)
+            .all()
+        )
+        return {
+            'available_balance': round_money(wallet.available_balance),
+            'available_balance_display': format_money(wallet.available_balance),
+            'payment_methods': [serialize_payment_method(method) for method in methods],
+            'default_payment_method_id': methods[0].id if methods else None,
+            'recent_entries': [serialize_wallet_entry(entry) for entry in entries],
+            'min_top_up_amount': MIN_TOP_UP_AMOUNT,
+            'max_top_up_amount': MAX_TOP_UP_AMOUNT,
+            'min_withdrawal_amount': MIN_WITHDRAWAL_AMOUNT,
+            'withdrawal_fee_rate_percent': int(WITHDRAWAL_FEE_RATE * 100),
+            'withdrawal_fee_minimum': WITHDRAWAL_FEE_MINIMUM,
+            'sensitive_hidden_by_default': True,
+        }
+
+    def build_purchase_wallet_context(user, item_price):
+        wallet = get_or_create_wallet(user, commit=True)
+        balance = round_money(wallet.available_balance)
+        item_total = round_money(item_price)
+        return {
+            'available_balance': balance,
+            'available_balance_display': format_money(balance),
+            'has_enough_funds': balance >= item_total,
+            'shortfall': round_money(max(0, item_total - balance)),
+            'shortfall_display': format_money(max(0, item_total - balance)),
+            'linked_payment_methods': len(get_user_payment_methods(user)),
+        }
 
     def csrf_failure():
         if request.path.startswith('/api/'):
@@ -329,6 +572,7 @@ def create_app(config_name='development'):
 
         return {
             'user': serialize_user(user, include_email=True),
+            'wallet': build_wallet_payload(user),
             'listings': [serialize_item(item) for item in user_items],
             'drafts': [serialize_item(item) for item in drafts],
             'purchases': [
@@ -525,6 +769,8 @@ def create_app(config_name='development'):
         user = User(username=username, email=email, full_name=full_name)
         user.set_password(password)
         db.session.add(user)
+        db.session.flush()
+        db.session.add(Wallet(user_id=user.id, available_balance=0.0))
         db.session.commit()
         return user, None, 201
 
@@ -671,16 +917,43 @@ def create_app(config_name='development'):
         if item.seller_id == buyer.id:
             return None, 'Cannot buy your own item', 400
 
+        buyer_wallet = get_or_create_wallet(buyer)
+        seller_wallet = get_or_create_wallet(item.seller)
+        item_price = round_money(item.price)
+        if buyer_wallet.available_balance < item_price:
+            shortfall = round_money(item_price - buyer_wallet.available_balance)
+            return None, (
+                f'Insufficient wallet balance. Top up ${format_money(shortfall)} more '
+                'from your linked bank card before purchasing this item.'
+            ), 400
+
         transaction = Transaction(
             item_id=item.id,
             seller_id=item.seller_id,
             buyer_id=buyer.id,
-            price=item.price,
+            price=item_price,
             status='completed',
         )
 
         item.is_sold = True
+        buyer_wallet.available_balance = round_money(buyer_wallet.available_balance - item_price)
+        seller_wallet.available_balance = round_money(seller_wallet.available_balance + item_price)
         db.session.add(transaction)
+        db.session.flush()
+        record_wallet_entry(
+            buyer_wallet,
+            'purchase',
+            -item_price,
+            f'Purchased {item.title}',
+            transaction=transaction,
+        )
+        record_wallet_entry(
+            seller_wallet,
+            'sale_proceeds',
+            item_price,
+            f'Sale proceeds held in wallet for {item.title}',
+            transaction=transaction,
+        )
         db.session.commit()
         return transaction, None, 200
 
@@ -749,6 +1022,7 @@ def create_app(config_name='development'):
     with app.app_context():
         db.create_all()
         ensure_schema_supports_drafts()
+        ensure_existing_users_have_wallets()
 
     @app.route('/')
     def index():
@@ -972,7 +1246,11 @@ def create_app(config_name='development'):
             flash(error, 'error')
             return redirect(url_for('item_detail_page', item_id=item.id))
 
-        flash(f'Purchase completed for {transaction.item.title}.', 'success')
+        flash(
+            f'Purchase completed for {transaction.item.title}. '
+            f'${format_money(transaction.price)} was paid from your wallet and moved into the seller wallet.',
+            'success',
+        )
         return redirect(url_for('dashboard_page'))
 
     @app.route('/item/<int:item_id>')
@@ -988,10 +1266,15 @@ def create_app(config_name='development'):
             flash('This listing is currently saved as a draft. Edit it to publish or continue working on it.', 'error')
             return redirect(url_for('edit_listing_page', item_id=item.id))
 
+        purchase_wallet = None
+        if current_user.is_authenticated and current_user.id != item.seller_id:
+            purchase_wallet = build_purchase_wallet_context(current_user, item.price)
+
         return render_template(
             'item_detail.html',
             item=serialize_item(item),
             chat=resolve_item_chat_context(item),
+            purchase_wallet=purchase_wallet,
         )
 
     @app.route('/item/<int:item_id>/conversation', methods=['POST'])
@@ -1036,6 +1319,64 @@ def create_app(config_name='development'):
         if conversation.item.seller_id == current_user.id:
             return redirect(url_for('item_detail_page', item_id=conversation.item.id, conversation=conversation.id) + '#chat')
         return redirect(url_for('dashboard_page', conversation=conversation.id) + '#inbox')
+
+    @app.route('/wallet/payment-methods', methods=['POST'])
+    @login_required
+    @csrf_protect
+    def wallet_payment_methods_page():
+        method, error, _ = add_payment_method(
+            current_user,
+            request.form.get('provider_name', ''),
+            request.form.get('account_holder', ''),
+            request.form.get('account_number', ''),
+            make_default=request.form.get('is_default') == 'on',
+        )
+        if error:
+            flash(error, 'error')
+            return redirect(url_for('dashboard_page') + '#wallet')
+
+        flash(f'Linked {method.masked_details}. Only masked payment details are stored in this demo.', 'success')
+        return redirect(url_for('dashboard_page') + '#wallet')
+
+    @app.route('/wallet/top-up', methods=['POST'])
+    @login_required
+    @csrf_protect
+    def wallet_top_up_page():
+        wallet, entry, error, _ = top_up_wallet(
+            current_user,
+            request.form.get('payment_method_id', type=int),
+            request.form.get('amount', ''),
+        )
+        if error:
+            flash(error, 'error')
+            return redirect(url_for('dashboard_page') + '#wallet')
+
+        flash(
+            f'Wallet topped up by ${format_money(entry.amount)}. '
+            f'Available balance is now ${format_money(wallet.available_balance)}.',
+            'success',
+        )
+        return redirect(url_for('dashboard_page') + '#wallet')
+
+    @app.route('/wallet/withdraw', methods=['POST'])
+    @login_required
+    @csrf_protect
+    def wallet_withdraw_page():
+        wallet, withdrawal_entry, fee_entry, error, _ = withdraw_from_wallet(
+            current_user,
+            request.form.get('payment_method_id', type=int),
+            request.form.get('amount', ''),
+        )
+        if error:
+            flash(error, 'error')
+            return redirect(url_for('dashboard_page') + '#wallet')
+
+        flash(
+            f'Withdrawal of ${format_money(abs(withdrawal_entry.amount))} requested to '
+            f'{withdrawal_entry.payment_method.masked_details}. Fee charged: ${format_money(abs(fee_entry.amount))}.',
+            'success',
+        )
+        return redirect(url_for('dashboard_page') + '#wallet')
 
     @app.route('/dashboard')
     @login_required
@@ -1203,7 +1544,7 @@ def create_app(config_name='development'):
 
         return jsonify({
             'success': True,
-            'message': 'Purchase completed successfully',
+            'message': 'Purchase completed successfully using wallet funds',
             'transaction': {
                 'id': transaction.id,
                 'item_id': transaction.item_id,
@@ -1345,6 +1686,10 @@ def create_app(config_name='development'):
                 'allowed_email_domain': UWA_STUDENT_DOMAIN,
                 'chat_enabled': True,
                 'max_images_per_item': MAX_IMAGES_PER_ITEM,
+                'wallet_enabled': True,
+                'min_top_up_amount': MIN_TOP_UP_AMOUNT,
+                'min_withdrawal_amount': MIN_WITHDRAWAL_AMOUNT,
+                'withdrawal_fee_rate_percent': int(WITHDRAWAL_FEE_RATE * 100),
             },
         }), 200
 

--- a/src/models.py
+++ b/src/models.py
@@ -24,6 +24,21 @@ class User(db.Model):
     seller_conversations = db.relationship('Conversation', backref='seller', lazy=True, foreign_keys='Conversation.seller_id')
     buyer_conversations = db.relationship('Conversation', backref='buyer', lazy=True, foreign_keys='Conversation.buyer_id')
     sent_messages = db.relationship('Message', backref='sender', lazy=True, foreign_keys='Message.sender_id')
+    wallet = db.relationship('Wallet', backref='user', uselist=False, cascade='all, delete-orphan')
+    payment_methods = db.relationship(
+        'PaymentMethod',
+        backref='user',
+        lazy=True,
+        cascade='all, delete-orphan',
+        order_by='PaymentMethod.created_at.desc()'
+    )
+    wallet_entries = db.relationship(
+        'WalletEntry',
+        backref='user',
+        lazy=True,
+        cascade='all, delete-orphan',
+        order_by='WalletEntry.created_at.desc()'
+    )
     
     def set_password(self, password):
         self.password_hash = generate_password_hash(password)
@@ -96,6 +111,64 @@ class Transaction(db.Model):
     
     def __repr__(self):
         return f'<Transaction {self.id}>'
+
+
+class Wallet(db.Model):
+    __tablename__ = 'wallets'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, unique=True, index=True)
+    available_balance = db.Column(db.Float, default=0.0, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    def __repr__(self):
+        return f'<Wallet user={self.user_id} balance={self.available_balance}>'
+
+
+class PaymentMethod(db.Model):
+    __tablename__ = 'payment_methods'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, index=True)
+    provider_name = db.Column(db.String(80), nullable=False)
+    account_holder = db.Column(db.String(120), nullable=False)
+    masked_details = db.Column(db.String(80), nullable=False)
+    last_four = db.Column(db.String(4), nullable=False)
+    method_type = db.Column(db.String(30), default='bank_card', nullable=False)
+    is_default = db.Column(db.Boolean, default=False, nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    __table_args__ = (
+        db.Index('idx_payment_method_user_created', 'user_id', 'created_at'),
+    )
+
+    def __repr__(self):
+        return f'<PaymentMethod user={self.user_id} last4={self.last_four}>'
+
+
+class WalletEntry(db.Model):
+    __tablename__ = 'wallet_entries'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False, index=True)
+    payment_method_id = db.Column(db.Integer, db.ForeignKey('payment_methods.id'), nullable=True, index=True)
+    transaction_id = db.Column(db.Integer, db.ForeignKey('transactions.id'), nullable=True, index=True)
+    entry_type = db.Column(db.String(40), nullable=False, index=True)
+    amount = db.Column(db.Float, nullable=False)
+    balance_after = db.Column(db.Float, nullable=False)
+    description = db.Column(db.String(255), nullable=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow, index=True)
+
+    payment_method = db.relationship('PaymentMethod', backref=db.backref('wallet_entries', lazy=True))
+    transaction = db.relationship('Transaction', backref=db.backref('wallet_entries', lazy=True))
+
+    __table_args__ = (
+        db.Index('idx_wallet_entry_user_created', 'user_id', 'created_at'),
+    )
+
+    def __repr__(self):
+        return f'<WalletEntry user={self.user_id} type={self.entry_type} amount={self.amount}>'
 
 
 class ItemImage(db.Model):

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -19,6 +19,10 @@ body {
     background-color: #f9f9f9;
 }
 
+body.modal-open {
+    overflow: hidden;
+}
+
 /* ============================================
    NAVBAR
    ============================================ */
@@ -252,6 +256,14 @@ main {
     background-color: #fee2e2;
     color: #b91c1c;
     border: 1px solid #fecaca;
+}
+
+.btn:disabled,
+.btn[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
 }
 
 .btn-sm {
@@ -649,6 +661,23 @@ main {
 .pricing-section button {
     width: 100%;
     margin-bottom: 0.5rem;
+}
+
+.wallet-purchase-note {
+    margin-top: 0.85rem;
+    padding: 0.85rem 1rem;
+    border-radius: 10px;
+    font-size: 0.95rem;
+}
+
+.wallet-purchase-note-ready {
+    background: #e8f7ee;
+    color: #166534;
+}
+
+.wallet-purchase-note-warning {
+    background: #fff4d6;
+    color: #92400e;
 }
 
 .item-description-section {
@@ -1204,6 +1233,10 @@ main {
     margin-bottom: 1.25rem;
 }
 
+.section-heading.compact {
+    margin-bottom: 0.9rem;
+}
+
 .section-heading p,
 .panel-text {
     color: #5f6b7a;
@@ -1545,10 +1578,163 @@ main {
     gap: 0.75rem;
 }
 
+.wallet-modal-backdrop {
+    align-items: flex-start;
+    overflow-y: auto;
+}
+
+.wallet-modal {
+    width: min(1120px, 100%);
+    margin: 2rem auto;
+    background: white;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.28);
+    display: grid;
+    gap: 1.25rem;
+}
+
+.wallet-modal-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.wallet-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.wallet-panel {
+    background: #f8fafc;
+    border: 1px solid #d7e4f0;
+    border-radius: 14px;
+    padding: 1.25rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.wallet-panel-wide {
+    grid-column: 1 / -1;
+}
+
+.wallet-panel-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.wallet-panel h3 {
+    color: #0f172a;
+}
+
+.wallet-balance {
+    font-size: 2.1rem;
+    font-weight: 800;
+    color: #003b5c;
+    letter-spacing: 0.02em;
+}
+
+.wallet-mini-metrics {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.wallet-mini-metric {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 0.85rem;
+    display: grid;
+    gap: 0.25rem;
+}
+
+.wallet-mini-label {
+    color: #64748b;
+    font-size: 0.85rem;
+}
+
+.wallet-method-list {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.wallet-method-card {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 0.9rem 1rem;
+}
+
+.wallet-form {
+    display: grid;
+    gap: 0.85rem;
+}
+
+.wallet-form .form-group {
+    margin-bottom: 0;
+}
+
+.wallet-check {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: #334155;
+    font-size: 0.92rem;
+}
+
+.wallet-check input {
+    width: auto;
+}
+
+.wallet-activity-list {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.wallet-activity-row {
+    background: white;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: 0.95rem 1rem;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.wallet-activity-meta {
+    display: grid;
+    gap: 0.3rem;
+    text-align: right;
+    white-space: nowrap;
+}
+
+.wallet-entry-amount {
+    font-weight: 700;
+}
+
+.wallet-entry-amount.positive {
+    color: #166534;
+}
+
+.wallet-entry-amount.negative {
+    color: #b91c1c;
+}
+
 @media (max-width: 768px) {
     .hero-campus,
     .info-banner,
     .dashboard-grid,
+    .wallet-grid,
     .conversation-layout {
         grid-template-columns: 1fr;
     }
@@ -1558,7 +1744,10 @@ main {
     }
 
     .dashboard-hero,
-    .chat-header {
+    .chat-header,
+    .wallet-modal-header,
+    .wallet-panel-header,
+    .wallet-activity-row {
         flex-direction: column;
     }
 
@@ -1574,6 +1763,15 @@ main {
 
     .message-bubble {
         max-width: 100%;
+    }
+
+    .wallet-mini-metrics {
+        grid-template-columns: 1fr;
+    }
+
+    .wallet-activity-meta {
+        text-align: left;
+        white-space: normal;
     }
 
     .search-box {

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -1616,6 +1616,11 @@ main {
     gap: 1rem;
 }
 
+.wallet-column-stack {
+    display: grid;
+    gap: 1rem;
+}
+
 .wallet-panel-wide {
     grid-column: 1 / -1;
 }

--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -380,9 +380,107 @@ function attachUnlistModal() {
     });
 }
 
+function attachWalletModal() {
+    const backdrop = document.getElementById('walletModalBackdrop');
+    const launchButtons = Array.from(document.querySelectorAll('[data-wallet-launch]'));
+    const closeButtons = Array.from(document.querySelectorAll('[data-wallet-close]'));
+
+    if (!backdrop || !launchButtons.length) {
+        return;
+    }
+
+    const currentUrlWithoutHash = () => `${window.location.pathname}${window.location.search}`;
+
+    const openModal = (syncHash = true) => {
+        backdrop.classList.remove('hidden');
+        document.body.classList.add('modal-open');
+        if (syncHash && window.location.hash !== '#wallet') {
+            history.replaceState(null, '', `${currentUrlWithoutHash()}#wallet`);
+        }
+    };
+
+    const closeModal = (syncHash = true) => {
+        backdrop.classList.add('hidden');
+        document.body.classList.remove('modal-open');
+        if (syncHash && window.location.hash === '#wallet') {
+            history.replaceState(null, '', currentUrlWithoutHash());
+        }
+    };
+
+    const syncWithHash = () => {
+        if (window.location.hash === '#wallet') {
+            openModal(false);
+        } else {
+            closeModal(false);
+        }
+    };
+
+    launchButtons.forEach((button) => {
+        button.addEventListener('click', (event) => {
+            event.preventDefault();
+            openModal(true);
+        });
+    });
+
+    closeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            closeModal(true);
+        });
+    });
+
+    backdrop.addEventListener('click', (event) => {
+        if (event.target === backdrop) {
+            closeModal(true);
+        }
+    });
+
+    window.addEventListener('hashchange', syncWithHash);
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !backdrop.classList.contains('hidden')) {
+            closeModal(true);
+        }
+    });
+
+    syncWithHash();
+}
+
+function attachWalletVisibilityToggle() {
+    const toggleButtons = Array.from(document.querySelectorAll('[data-wallet-toggle]'));
+    const sensitiveValues = Array.from(document.querySelectorAll('[data-wallet-sensitive]'));
+
+    if (!toggleButtons.length || !sensitiveValues.length) {
+        return;
+    }
+
+    let isVisible = window.localStorage.getItem('walletSensitiveVisible') === 'true';
+
+    const renderState = () => {
+        sensitiveValues.forEach((node) => {
+            node.textContent = isVisible ? (node.dataset.value || '') : '****';
+        });
+
+        toggleButtons.forEach((button) => {
+            button.textContent = isVisible ? 'Hide balances' : 'Reveal balances';
+            button.setAttribute('aria-pressed', isVisible ? 'true' : 'false');
+        });
+    };
+
+    toggleButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            isVisible = !isVisible;
+            window.localStorage.setItem('walletSensitiveVisible', isVisible ? 'true' : 'false');
+            renderState();
+        });
+    });
+
+    renderState();
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     attachSellImagePicker();
     attachItemGallery();
     attachChatWidgets();
     attachUnlistModal();
+    attachWalletModal();
+    attachWalletVisibilityToggle();
 });

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -16,6 +16,7 @@
             <div class="dashboard-actions">
                 <a href="{{ url_for('sell_item_page') }}" class="btn btn-primary">Post a new item</a>
                 <a href="{{ url_for('browse_items') }}" class="btn btn-secondary">Browse market</a>
+                <button type="button" class="btn btn-ghost" data-wallet-launch>Open wallet</button>
             </div>
         </div>
 
@@ -207,6 +208,19 @@
             </div>
         </section>
     </section>
+
+    <div class="modal-backdrop wallet-modal-backdrop hidden" id="walletModalBackdrop">
+        <div class="wallet-modal" role="dialog" aria-modal="true" aria-labelledby="walletModalTitle">
+            <div class="wallet-modal-header">
+                <div>
+                    <h2 id="walletModalTitle">Wallet & payouts</h2>
+                    <p class="panel-text">Manage your balance, linked cards, top-ups, and withdrawals without leaving the inbox.</p>
+                </div>
+                <button type="button" class="btn btn-ghost btn-sm" data-wallet-close>Close</button>
+            </div>
+            {% include 'partials/wallet_workspace.html' %}
+        </div>
+    </div>
 
     <div class="modal-backdrop hidden" id="unlistModalBackdrop">
         <div class="decision-modal" role="dialog" aria-modal="true" aria-labelledby="unlistModalTitle">

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -6,7 +6,7 @@
     <section class="dashboard-container">
         <div class="dashboard-hero">
             <div>
-                <h1>{{ dashboard.user.full_name }}</h1>
+                <h1>{{ dashboard.user.username }}</h1>
                 <p class="panel-text">{{ dashboard.user.email }}</p>
                 <div class="item-badges">
                     {% set user = dashboard.user %}

--- a/src/templates/item_detail.html
+++ b/src/templates/item_detail.html
@@ -58,8 +58,20 @@
                 {% if current_user.is_authenticated and current_user.id != item.seller.id and not item.is_sold %}
                     <form method="post" action="{{ url_for('purchase_page', item_id=item.id) }}">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-                        <button type="submit" class="btn btn-primary">Buy now</button>
+                        <button type="submit" class="btn btn-primary">Buy with wallet</button>
                     </form>
+                    {% if purchase_wallet %}
+                        <p class="wallet-purchase-note {% if purchase_wallet.has_enough_funds %}wallet-purchase-note-ready{% else %}wallet-purchase-note-warning{% endif %}">
+                            Wallet balance:
+                            <strong>${{ purchase_wallet.available_balance_display }}</strong>.
+                            {% if purchase_wallet.has_enough_funds %}
+                                You have enough funds for this checkout.
+                            {% else %}
+                                You need ${{ purchase_wallet.shortfall_display }} more. Top up from your
+                                <a href="{{ url_for('dashboard_page') }}#wallet">wallet</a> first.
+                            {% endif %}
+                        </p>
+                    {% endif %}
                 {% elif current_user.is_authenticated and current_user.id == item.seller.id %}
                     <a href="{{ url_for('dashboard_page') }}" class="btn btn-secondary">Open dashboard</a>
                 {% else %}

--- a/src/templates/partials/wallet_workspace.html
+++ b/src/templates/partials/wallet_workspace.html
@@ -24,6 +24,55 @@
         </div>
     </article>
 
+    <div class="wallet-column-stack">
+        <article class="wallet-panel">
+            <div class="section-heading compact">
+                <h3>Top up wallet</h3>
+                <p>Move money from a linked bank card into your on-platform balance before checkout.</p>
+            </div>
+            <form method="post" action="{{ url_for('wallet_top_up_page') }}" class="wallet-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <div class="form-group">
+                    <label for="topUpMethod">Top up from</label>
+                    <select id="topUpMethod" name="payment_method_id" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>
+                        {% for method in dashboard.wallet.payment_methods %}
+                            <option value="{{ method.id }}" {% if method.is_default %}selected{% endif %}>{{ method.provider_name }} ending {{ method.last_four }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="topUpAmount">Top-up amount</label>
+                    <input id="topUpAmount" name="amount" type="number" step="0.01" min="{{ '%.2f'|format(dashboard.wallet.min_top_up_amount) }}" placeholder="50.00" required>
+                </div>
+                <button type="submit" class="btn btn-primary" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>Top up wallet</button>
+            </form>
+        </article>
+
+        <article class="wallet-panel">
+            <div class="section-heading compact">
+                <h3>Withdraw to bank</h3>
+                <p>Move sale proceeds or remaining wallet balance back to one of your linked cards.</p>
+            </div>
+            <form method="post" action="{{ url_for('wallet_withdraw_page') }}" class="wallet-form">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <div class="form-group">
+                    <label for="withdrawMethod">Withdraw to</label>
+                    <select id="withdrawMethod" name="payment_method_id" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>
+                        {% for method in dashboard.wallet.payment_methods %}
+                            <option value="{{ method.id }}" {% if method.is_default %}selected{% endif %}>{{ method.provider_name }} ending {{ method.last_four }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="withdrawAmount">Amount to send to your bank</label>
+                    <input id="withdrawAmount" name="amount" type="number" step="0.01" min="{{ '%.2f'|format(dashboard.wallet.min_withdrawal_amount) }}" placeholder="20.00" required>
+                </div>
+                <p class="panel-text">A {{ dashboard.wallet.withdrawal_fee_rate_percent }}% processing fee applies, with a minimum fee of ${{ '%.2f'|format(dashboard.wallet.withdrawal_fee_minimum) }}.</p>
+                <button type="submit" class="btn btn-secondary" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>Withdraw to bank</button>
+            </form>
+        </article>
+    </div>
+
     <article class="wallet-panel">
         <div class="section-heading compact">
             <h3>Linked bank cards</h3>
@@ -67,47 +116,6 @@
                 Set as default payment method
             </label>
             <button type="submit" class="btn btn-secondary">Link card</button>
-        </form>
-    </article>
-
-    <article class="wallet-panel">
-        <div class="section-heading compact">
-            <h3>Top up and withdraw</h3>
-            <p>Buyers spend from wallet funds. Sellers receive sale proceeds in this wallet until they withdraw.</p>
-        </div>
-        <form method="post" action="{{ url_for('wallet_top_up_page') }}" class="wallet-form">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-            <div class="form-group">
-                <label for="topUpMethod">Top up from</label>
-                <select id="topUpMethod" name="payment_method_id" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>
-                    {% for method in dashboard.wallet.payment_methods %}
-                        <option value="{{ method.id }}" {% if method.is_default %}selected{% endif %}>{{ method.provider_name }} ending {{ method.last_four }}</option>
-                    {% endfor %}
-                </select>
-            </div>
-            <div class="form-group">
-                <label for="topUpAmount">Top-up amount</label>
-                <input id="topUpAmount" name="amount" type="number" step="0.01" min="{{ '%.2f'|format(dashboard.wallet.min_top_up_amount) }}" placeholder="50.00" required>
-            </div>
-            <button type="submit" class="btn btn-primary" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>Top up wallet</button>
-        </form>
-
-        <form method="post" action="{{ url_for('wallet_withdraw_page') }}" class="wallet-form">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-            <div class="form-group">
-                <label for="withdrawMethod">Withdraw to</label>
-                <select id="withdrawMethod" name="payment_method_id" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>
-                    {% for method in dashboard.wallet.payment_methods %}
-                        <option value="{{ method.id }}" {% if method.is_default %}selected{% endif %}>{{ method.provider_name }} ending {{ method.last_four }}</option>
-                    {% endfor %}
-                </select>
-            </div>
-            <div class="form-group">
-                <label for="withdrawAmount">Amount to send to your bank</label>
-                <input id="withdrawAmount" name="amount" type="number" step="0.01" min="{{ '%.2f'|format(dashboard.wallet.min_withdrawal_amount) }}" placeholder="20.00" required>
-            </div>
-            <p class="panel-text">A {{ dashboard.wallet.withdrawal_fee_rate_percent }}% processing fee applies, with a minimum fee of ${{ '%.2f'|format(dashboard.wallet.withdrawal_fee_minimum) }}.</p>
-            <button type="submit" class="btn btn-secondary" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>Withdraw to bank</button>
         </form>
     </article>
 

--- a/src/templates/partials/wallet_workspace.html
+++ b/src/templates/partials/wallet_workspace.html
@@ -1,0 +1,148 @@
+<div class="section-heading">
+    <h2>Wallet & payouts</h2>
+    <p>Funds from completed campus trades stay inside your on-platform wallet until you withdraw them to a linked bank card.</p>
+</div>
+
+<div class="wallet-grid">
+    <article class="wallet-panel">
+        <div class="wallet-panel-header">
+            <div>
+                <h3>On-platform balance</h3>
+                <p class="panel-text">Use this balance directly for new purchases or withdraw it to your bank.</p>
+            </div>
+            <button type="button" class="btn btn-sm btn-ghost" data-wallet-toggle>Reveal balances</button>
+        </div>
+        <div class="wallet-balance" data-wallet-sensitive data-value="${{ '%.2f'|format(dashboard.wallet.available_balance) }}">••••••</div>
+        <div class="wallet-mini-metrics">
+            <div class="wallet-mini-metric">
+                <span class="wallet-mini-label">Linked cards</span>
+                <strong>{{ dashboard.wallet.payment_methods|length }}</strong>
+            </div>
+            <div class="wallet-mini-metric">
+                <span class="wallet-mini-label">Withdrawal fee</span>
+                <strong>{{ dashboard.wallet.withdrawal_fee_rate_percent }}% min ${{ '%.2f'|format(dashboard.wallet.withdrawal_fee_minimum) }}</strong>
+            </div>
+            <div class="wallet-mini-metric">
+                <span class="wallet-mini-label">Top-up range</span>
+                <strong>${{ '%.2f'|format(dashboard.wallet.min_top_up_amount) }} - ${{ '%.2f'|format(dashboard.wallet.max_top_up_amount) }}</strong>
+            </div>
+        </div>
+    </article>
+
+    <article class="wallet-panel">
+        <div class="section-heading compact">
+            <h3>Linked bank cards</h3>
+            <p>Only masked payment details are stored for this coursework demo.</p>
+        </div>
+        {% if dashboard.wallet.payment_methods %}
+            <div class="wallet-method-list">
+                {% for method in dashboard.wallet.payment_methods %}
+                    <div class="wallet-method-card">
+                        <div>
+                            <strong>{{ method.provider_name }}</strong>
+                            <p>{{ method.account_holder }}</p>
+                            <p class="panel-text">{{ method.masked_details }}</p>
+                        </div>
+                        {% if method.is_default %}
+                            <span class="campus-pill">Default</span>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="empty-state compact">No payment methods linked yet. Add a bank card before topping up or withdrawing.</div>
+        {% endif %}
+
+        <form method="post" action="{{ url_for('wallet_payment_methods_page') }}" class="wallet-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="form-group">
+                <label for="providerName">Bank / provider</label>
+                <input id="providerName" name="provider_name" type="text" placeholder="Commonwealth Bank" required>
+            </div>
+            <div class="form-group">
+                <label for="accountHolder">Cardholder name</label>
+                <input id="accountHolder" name="account_holder" type="text" placeholder="UWA Student" required>
+            </div>
+            <div class="form-group">
+                <label for="accountNumber">Bank card number</label>
+                <input id="accountNumber" name="account_number" type="text" inputmode="numeric" placeholder="4111 1111 1111 1111" required>
+            </div>
+            <label class="wallet-check">
+                <input type="checkbox" name="is_default" checked>
+                Set as default payment method
+            </label>
+            <button type="submit" class="btn btn-secondary">Link card</button>
+        </form>
+    </article>
+
+    <article class="wallet-panel">
+        <div class="section-heading compact">
+            <h3>Top up and withdraw</h3>
+            <p>Buyers spend from wallet funds. Sellers receive sale proceeds in this wallet until they withdraw.</p>
+        </div>
+        <form method="post" action="{{ url_for('wallet_top_up_page') }}" class="wallet-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="form-group">
+                <label for="topUpMethod">Top up from</label>
+                <select id="topUpMethod" name="payment_method_id" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>
+                    {% for method in dashboard.wallet.payment_methods %}
+                        <option value="{{ method.id }}" {% if method.is_default %}selected{% endif %}>{{ method.provider_name }} ending {{ method.last_four }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="topUpAmount">Top-up amount</label>
+                <input id="topUpAmount" name="amount" type="number" step="0.01" min="{{ '%.2f'|format(dashboard.wallet.min_top_up_amount) }}" placeholder="50.00" required>
+            </div>
+            <button type="submit" class="btn btn-primary" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>Top up wallet</button>
+        </form>
+
+        <form method="post" action="{{ url_for('wallet_withdraw_page') }}" class="wallet-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="form-group">
+                <label for="withdrawMethod">Withdraw to</label>
+                <select id="withdrawMethod" name="payment_method_id" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>
+                    {% for method in dashboard.wallet.payment_methods %}
+                        <option value="{{ method.id }}" {% if method.is_default %}selected{% endif %}>{{ method.provider_name }} ending {{ method.last_four }}</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="withdrawAmount">Amount to send to your bank</label>
+                <input id="withdrawAmount" name="amount" type="number" step="0.01" min="{{ '%.2f'|format(dashboard.wallet.min_withdrawal_amount) }}" placeholder="20.00" required>
+            </div>
+            <p class="panel-text">A {{ dashboard.wallet.withdrawal_fee_rate_percent }}% processing fee applies, with a minimum fee of ${{ '%.2f'|format(dashboard.wallet.withdrawal_fee_minimum) }}.</p>
+            <button type="submit" class="btn btn-secondary" {% if not dashboard.wallet.payment_methods %}disabled{% endif %}>Withdraw to bank</button>
+        </form>
+    </article>
+
+    <article class="wallet-panel wallet-panel-wide">
+        <div class="section-heading compact">
+            <h3>Recent wallet activity</h3>
+            <p>Every top-up, purchase, sale credit, and withdrawal is recorded here.</p>
+        </div>
+        {% if dashboard.wallet.recent_entries %}
+            <div class="wallet-activity-list">
+                {% for entry in dashboard.wallet.recent_entries %}
+                    <div class="wallet-activity-row">
+                        <div>
+                            <strong>{{ entry.description }}</strong>
+                            <p class="panel-text">{{ entry.created_at_display }}</p>
+                        </div>
+                        <div class="wallet-activity-meta">
+                            <span class="wallet-entry-amount {% if entry.amount > 0 %}positive{% else %}negative{% endif %}" data-wallet-sensitive data-value="{% if entry.amount > 0 %}+{% endif %}${{ '%.2f'|format(entry.amount|abs) }}">
+                                ••••
+                            </span>
+                            <span class="panel-text">
+                                Balance after:
+                                <span data-wallet-sensitive data-value="${{ '%.2f'|format(entry.balance_after) }}">••••</span>
+                            </span>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% else %}
+            <div class="empty-state compact">No wallet activity yet. Link a bank card, top up, or complete a sale to start building your wallet history.</div>
+        {% endif %}
+    </article>
+</div>

--- a/src/templates/partials/wallet_workspace.html
+++ b/src/templates/partials/wallet_workspace.html
@@ -1,8 +1,3 @@
-<div class="section-heading">
-    <h2>Wallet & payouts</h2>
-    <p>Funds from completed campus trades stay inside your on-platform wallet until you withdraw them to a linked bank card.</p>
-</div>
-
 <div class="wallet-grid">
     <article class="wallet-panel">
         <div class="wallet-panel-header">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,7 @@
 import unittest
 
 from src.app import create_app
-from models import Conversation, Item, Message, User, db
+from models import Conversation, Item, Message, PaymentMethod, Transaction, User, Wallet, WalletEntry, db
 
 
 class MarketplaceAppTestCase(unittest.TestCase):
@@ -57,6 +57,22 @@ class MarketplaceAppTestCase(unittest.TestCase):
         db.session.add(user)
         db.session.commit()
         return user
+
+    def link_payment_method(self, provider_name='CommBank', account_holder='Test User', account_number='4111111111111111'):
+        csrf_token = self.get_csrf_token()
+        return self.post_form('/wallet/payment-methods', {
+            'provider_name': provider_name,
+            'account_holder': account_holder,
+            'account_number': account_number,
+            'is_default': 'on',
+        }, csrf_token=csrf_token)
+
+    def top_up_wallet(self, amount, payment_method_id=None):
+        csrf_token = self.get_csrf_token()
+        payload = {'amount': amount}
+        if payment_method_id:
+            payload['payment_method_id'] = payment_method_id
+        return self.post_form('/wallet/top-up', payload, csrf_token=csrf_token)
 
     def test_root_route_serves_home_page(self):
         response = self.client.get('/')
@@ -123,6 +139,32 @@ class MarketplaceAppTestCase(unittest.TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertTrue(data['success'])
         self.assertEqual(data['item']['title'], 'Desk Lamp')
+
+    def test_wallet_payment_method_and_top_up_store_masked_details(self):
+        self.register_user('walletuser', 'walletuser@student.uwa.edu.au')
+        self.login_user('walletuser')
+
+        link_response = self.link_payment_method()
+        self.assertEqual(link_response.status_code, 302)
+
+        with self.app.app_context():
+            user = User.query.filter_by(username='walletuser').first()
+            payment_method = PaymentMethod.query.filter_by(user_id=user.id).first()
+            self.assertIsNotNone(payment_method)
+            self.assertEqual(payment_method.last_four, '1111')
+            self.assertIn('•••• 1111', payment_method.masked_details)
+            self.assertNotIn('4111111111111111', payment_method.masked_details)
+
+        top_up_response = self.top_up_wallet('75.00')
+        self.assertEqual(top_up_response.status_code, 302)
+
+        with self.app.app_context():
+            user = User.query.filter_by(username='walletuser').first()
+            wallet = Wallet.query.filter_by(user_id=user.id).first()
+            top_up_entry = WalletEntry.query.filter_by(user_id=user.id, entry_type='top_up').first()
+            self.assertIsNotNone(wallet)
+            self.assertAlmostEqual(wallet.available_balance, 75.0)
+            self.assertIsNotNone(top_up_entry)
 
     def test_save_draft_hides_listing_from_public_browse(self):
         self.register_user('seller', 'seller@student.uwa.edu.au')
@@ -198,6 +240,123 @@ class MarketplaceAppTestCase(unittest.TestCase):
 
         with self.app.app_context():
             self.assertIsNone(db.session.get(Item, item_id))
+
+    def test_purchase_uses_wallet_balance_and_credits_seller_wallet(self):
+        with self.app.app_context():
+            seller = self.create_user('sellerwallet', 'sellerwallet@student.uwa.edu.au', full_name='Seller Wallet')
+            buyer = self.create_user('buyerwallet', 'buyerwallet@student.uwa.edu.au', full_name='Buyer Wallet')
+            item = Item(
+                title='Monitor',
+                description='24-inch monitor suitable for campus study setups.',
+                price=80,
+                category='Electronics',
+                condition='Good',
+                seller_id=seller.id,
+            )
+            db.session.add(item)
+            db.session.commit()
+            item_id = item.id
+
+        self.login_user('buyerwallet')
+        self.link_payment_method(provider_name='NAB', account_holder='Buyer Wallet', account_number='4000123412341234')
+        self.top_up_wallet('100.00')
+        csrf_token = self.get_csrf_token()
+        purchase_response = self.post_form(f'/purchase/{item_id}', {}, csrf_token=csrf_token)
+        self.assertEqual(purchase_response.status_code, 302)
+
+        with self.app.app_context():
+            transaction = Transaction.query.filter_by(item_id=item_id, status='completed').first()
+            buyer = User.query.filter_by(username='buyerwallet').first()
+            seller = User.query.filter_by(username='sellerwallet').first()
+            buyer_wallet = Wallet.query.filter_by(user_id=buyer.id).first()
+            seller_wallet = Wallet.query.filter_by(user_id=seller.id).first()
+            purchase_entry = WalletEntry.query.filter_by(user_id=buyer.id, entry_type='purchase').first()
+            sale_entry = WalletEntry.query.filter_by(user_id=seller.id, entry_type='sale_proceeds').first()
+            item = db.session.get(Item, item_id)
+
+            self.assertIsNotNone(transaction)
+            self.assertTrue(item.is_sold)
+            self.assertAlmostEqual(buyer_wallet.available_balance, 20.0)
+            self.assertAlmostEqual(seller_wallet.available_balance, 80.0)
+            self.assertIsNotNone(purchase_entry)
+            self.assertIsNotNone(sale_entry)
+
+    def test_purchase_fails_when_wallet_balance_is_insufficient(self):
+        with self.app.app_context():
+            seller = self.create_user('sellerlow', 'sellerlow@student.uwa.edu.au')
+            buyer = self.create_user('buyerlow', 'buyerlow@student.uwa.edu.au')
+            item = Item(
+                title='Desk',
+                description='Solid desk for a dorm room or study nook.',
+                price=55,
+                category='Furniture',
+                condition='Good',
+                seller_id=seller.id,
+            )
+            db.session.add(item)
+            db.session.commit()
+            item_id = item.id
+
+        self.login_user('buyerlow')
+        csrf_token = self.get_csrf_token()
+        response = self.post_json(f'/api/purchase/{item_id}', {}, csrf_token=csrf_token)
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(data['success'])
+        self.assertIn('Insufficient wallet balance', data['error'])
+
+    def test_withdrawal_applies_processing_fee(self):
+        with self.app.app_context():
+            user = self.create_user('withdrawuser', 'withdrawuser@student.uwa.edu.au', full_name='Withdraw User')
+            wallet = Wallet(user_id=user.id, available_balance=120.0)
+            method = PaymentMethod(
+                user_id=user.id,
+                provider_name='ANZ',
+                account_holder='Withdraw User',
+                masked_details='ANZ •••• 3456',
+                last_four='3456',
+                is_default=True,
+            )
+            db.session.add_all([wallet, method])
+            db.session.commit()
+            method_id = method.id
+
+        self.login_user('withdrawuser')
+        csrf_token = self.get_csrf_token()
+        response = self.post_form('/wallet/withdraw', {
+            'payment_method_id': method_id,
+            'amount': '30.00',
+        }, csrf_token=csrf_token)
+        self.assertEqual(response.status_code, 302)
+
+        with self.app.app_context():
+            user = User.query.filter_by(username='withdrawuser').first()
+            wallet = Wallet.query.filter_by(user_id=user.id).first()
+            withdrawal_entry = WalletEntry.query.filter_by(user_id=user.id, entry_type='withdrawal').first()
+            fee_entry = WalletEntry.query.filter_by(user_id=user.id, entry_type='withdrawal_fee').first()
+
+            self.assertAlmostEqual(wallet.available_balance, 89.4)
+            self.assertIsNotNone(withdrawal_entry)
+            self.assertIsNotNone(fee_entry)
+            self.assertAlmostEqual(abs(fee_entry.amount), 0.6)
+
+    def test_dashboard_masks_wallet_balances_by_default(self):
+        with self.app.app_context():
+            user = self.create_user('maskeduser', 'maskeduser@student.uwa.edu.au')
+            wallet = Wallet(user_id=user.id, available_balance=88.75)
+            db.session.add(wallet)
+            db.session.commit()
+
+        self.login_user('maskeduser')
+        response = self.client.get('/dashboard')
+        body = response.get_data(as_text=True)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('data-wallet-launch', body)
+        self.assertIn('wallet-modal-backdrop hidden', body)
+        self.assertIn('data-wallet-toggle', body)
+        self.assertIn('data-wallet-sensitive', body)
 
     def test_buyer_can_start_conversation_and_send_message(self):
         with self.app.app_context():


### PR DESCRIPTION
## Summary

This PR adds the wallet workflow to the dashboard/inbox experience and refines several related UI details on the `ryan_b` branch.

## What changed

- added the wallet feature prototype for the inbox/dashboard flow
- changed the wallet to open as a modal subpage instead of showing by default in the inbox page
- improved wallet layout:
  - linked bank cards moved to the right side
  - top-up and withdraw split into two separate stacked sections in the middle
  - wallet headings and card grouping cleaned up
- removed redundant wallet headings
- fixed wallet box styling and spacing issues
- changed the dashboard header display to use `username` instead of `full_name`
- updated the default local app port to `5000`
- merged the latest `main` into `ryan_b` and resolved the `src/static/js/main.js` conflict by keeping both:
  - wallet modal / wallet visibility logic
  - user dropdown logic from `main`

## Why

These changes make the wallet flow match the intended UX more closely:
- wallet stays hidden until the user explicitly opens it
- wallet actions are easier to scan and use
- inbox/dashboard identity display is now more consistent with the username-based UI

## Testing

- resolved merge conflicts locally
- verified the wallet modal and dashboard UI behavior after merge
- ran project tests locally

## Notes

- this PR includes UI and interaction refinements on top of the wallet prototype
- after merge, the dashboard/inbox experience should remain compatible with the latest `main` branch changes
